### PR TITLE
Internal fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.feth</groupId>
     <artifactId>mailfred-appengine</artifactId>
 
-        <pluginRepositories>
+    <pluginRepositories>
         <pluginRepository>
             <id>google-staging</id>
             <name>Google Staging</name>
@@ -20,8 +20,11 @@
 
     <properties>
         <appengine.app.version>1</appengine.app.version>
-        <appengine.target.version>1.9.17</appengine.target.version>
+        <appengine.target.version>1.9.48</appengine.target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- App Engine Standard currently requires Java 7 -->
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
     </properties>
 
     <dependencies>

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>mailfred-app</application>
-    <version>2</version>
+    <application>mailfred-stripe</application>
+    <version>1</version>
     <threadsafe>true</threadsafe>
     <system-properties>
         <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>

--- a/src/main/webapp/WEB-INF/datastore-indexes.xml
+++ b/src/main/webapp/WEB-INF/datastore-indexes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<datastore-indexes autoGenerate="true">
+    <datastore-index kind="ScheduledMail" ancestor="false" source="manual">
+        <property name="hasBeenProcessed" direction="asc"/>
+        <property name="scheduledFor" direction="asc"/>
+    </datastore-index>
+</datastore-indexes>

--- a/src/main/webapp/WEB-INF/logging.properties
+++ b/src/main/webapp/WEB-INF/logging.properties
@@ -1,2 +1,2 @@
 # Set the default logging level for all loggers to WARNING
-.level = FINEST
+.level = INFO   


### PR DESCRIPTION
Initial fork with changes to make it work on GAE with latest app-engine SDK.

Changes:
* Update to latest app-engine SDK
* Fix compiler version to 7 for Java as app-engine is incompatible with Java 8
* Add datastore-indexes.xml
* Reduce logging level from FINEST -> INFO to reduce log chunder